### PR TITLE
[REVIEW] Fix init scripts

### DIFF
--- a/init/aws-ebs-gpu.sh
+++ b/init/aws-ebs-gpu.sh
@@ -22,7 +22,9 @@ sudo chown -R jenkins:jenkins /jenkins
 
 logger "Override docker setup and utilize internal docker registry mirror"
 sudo service docker stop
-sudo cat /etc/docker/daemon.json
+if [ -f /etc/docker/daemon.json ]; then
+  sudo cat /etc/docker/daemon.json
+fi
 cat <<EOL > /tmp/daemon.json
 {
     "runtimes": {

--- a/init/aws-ebs-nvdocker.sh
+++ b/init/aws-ebs-nvdocker.sh
@@ -19,7 +19,9 @@ sudo chown -R ubuntu:ubuntu /jenkins
 
 # Override docker setup and utilize internal docker registry mirror
 sudo service docker stop
-sudo cat /etc/docker/daemon.json
+if [ -f /etc/docker/daemon.json ]; then
+  sudo cat /etc/docker/daemon.json
+fi
 cat <<EOL > /tmp/daemon.json
 {
     "runtimes": {

--- a/init/aws-ebs.sh
+++ b/init/aws-ebs.sh
@@ -22,7 +22,9 @@ sudo chown -R ubuntu:ubuntu /jenkins
 
 logger "Override docker setup and utilize internal docker registry mirror"
 sudo service docker stop
-sudo cat /etc/docker/daemon.json
+if [ -f /etc/docker/daemon.json ]; then
+  sudo cat /etc/docker/daemon.json
+fi
 cat <<EOL > /tmp/daemon.json
 {
     "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],

--- a/init/aws-nvme-docker-gpu.sh
+++ b/init/aws-nvme-docker-gpu.sh
@@ -56,7 +56,9 @@ cat <<EOL > /tmp/daemon.json
 }
 EOL
 sudo mv /tmp/daemon.json /etc/docker/daemon.json
-sudo cat /etc/docker/daemon.json
+if [ -f /etc/docker/daemon.json ]; then
+  sudo cat /etc/docker/daemon.json
+fi
 
 logger "Move docker to nvme on /jenkins"
 if [ ! -d /jenkins/docker ] ; then

--- a/init/aws-nvme-docker.sh
+++ b/init/aws-nvme-docker.sh
@@ -41,7 +41,9 @@ fi
   
 logger "Override docker setup and utilize internal docker registry mirror"
 sudo service docker stop
-sudo cat /etc/docker/daemon.json
+if [ -f /etc/docker/daemon.json ]; then
+  sudo cat /etc/docker/daemon.json
+fi
 cat <<EOL > /tmp/daemon.json
 {
     "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],

--- a/init/aws-nvme.sh
+++ b/init/aws-nvme.sh
@@ -41,7 +41,9 @@ fi
   
 logger "Override docker setup and utilize internal docker registry mirror"
 sudo service docker stop
-sudo cat /etc/docker/daemon.json
+if [ -f /etc/docker/daemon.json ]; then
+  sudo cat /etc/docker/daemon.json
+fi
 cat <<EOL > /tmp/daemon.json
 {
     "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
-sleep 30
+#sleep 30
 df -h
 lsblk
 apt-get update

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
-#sleep 30
+sleep 30
 df -h
 lsblk
 apt-get update

--- a/templates/playbook.yml
+++ b/templates/playbook.yml
@@ -1,0 +1,16 @@
+---
+- name: CPU
+  hosts: cpu
+  become: yes
+  roles:
+    - common
+    - cpu
+    - post_common
+
+- name: GPU
+  hosts: gpu
+  become: yes
+  roles:
+    - common
+    - gpu
+    - post_common

--- a/templates/playbook_cpu.yml
+++ b/templates/playbook_cpu.yml
@@ -1,8 +1,0 @@
----
-- name: Common Configuration for All Nodes
-  hosts: all
-  become: yes
-  roles:
-    - common
-    - cpu
-    - post_common

--- a/templates/playbook_gpu.yml
+++ b/templates/playbook_gpu.yml
@@ -1,8 +1,0 @@
----
-- name: Common Configuration for All Nodes
-  hosts: all
-  become: yes
-  roles:
-    - common
-    - gpu
-    - post_common

--- a/templates/template.json
+++ b/templates/template.json
@@ -52,7 +52,10 @@
         },
         {
             "type": "ansible",
-            "playbook_file": "playbook_{{user `type`}}.yml",
+            "playbook_file": "playbook.yml",
+            "groups": [
+                "{{user `type`}}"
+            ],
             "user": "ubuntu"
         },
         {


### PR DESCRIPTION
The new AMIs do not have `/etc/docker/daemon.json`, so the `cat` command fails and break init.

See: https://gpuci.gpuopenanalytics.com/computer/EC2%20(aws)%20-%20ami-test-c-m5dxl-b%20(i-0308fd1913dc588ae)/log