### PR TITLE
Add pip args

### DIFF
--- a/templates/roles/common/tasks/main.yml
+++ b/templates/roles/common/tasks/main.yml
@@ -37,10 +37,12 @@
 - name: Install pip packages
   pip:
     executable: pip3
+    extra_args: --ignore-installed
     name:
       - requests
       - PyYaml
       - jinja2
+    state: latest
 
 - name: Make sure we have a 'wheel' group
   group:


### PR DESCRIPTION
This PR introduces some extra arguments for the `pip` task in Ansible to make sure it installs the latest versions of `pip` packages. Before this PR, there were some issues with Ansible not installing the latest versions of `PyYAML` and `Jinja2` since they come preinstalled on Ubuntu.