### PR TITLE
[REVIEW] Adds chrony for NTP and a reboot for GPU

### DIFF
--- a/templates/roles/common/files/chrony.conf
+++ b/templates/roles/common/files/chrony.conf
@@ -1,0 +1,43 @@
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usuable directives.
+
+# This will use (up to):
+# - 4 sources from ntp.ubuntu.com which some are ipv6 enabled
+# - 2 sources from 2.ubuntu.pool.ntp.org which is ipv6 enabled as well
+# - 1 source from [01].ubuntu.pool.ntp.org each (ipv4 only atm)
+# This means by default, up to 6 dual-stack and up to 2 additional IPv4-only
+# sources will be used.
+# At the same time it retains some protection against one of the entries being
+# down (compare to just using one of the lines). See (LP: #1754358) for the
+# discussion.
+#
+# About using servers from the NTP Pool Project in general see (LP: #104525).
+# Approved by Ubuntu Technical Board on 2011-02-08.
+# See http://www.pool.ntp.org/join.html for more information.
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+rtcsync
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+makestep 1 3
+#172.31.29.62 is private IP for jenkins-prod
+server 172.31.29.62 iburst

--- a/templates/roles/common/handlers/main.yaml
+++ b/templates/roles/common/handlers/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: restart chrony
+  service:
+    name: chrony
+    state: restarted

--- a/templates/roles/common/tasks/main.yml
+++ b/templates/roles/common/tasks/main.yml
@@ -9,7 +9,6 @@
       - git
       - git-lfs
       - nvme-cli
-      - ntp
       - build-essential
       - wget
       - curl
@@ -21,6 +20,14 @@
       - software-properties-common
       - unzip
       - sudo
+      - chrony
+
+- name: Configure Chrony
+  copy:
+    src: chrony.conf
+    dest: /etc/chrony/chrony.conf
+    mode: 0644
+  notify: restart chrony
 
 - name: Initialize git-lfs
   command: git lfs install

--- a/templates/roles/gpu/tasks/main.yml
+++ b/templates/roles/gpu/tasks/main.yml
@@ -59,3 +59,6 @@
   command: git lfs install
   become: yes
   become_user: jenkins
+
+- name: Reboot
+  reboot: {}


### PR DESCRIPTION
Adds `chrony` to sync time with Jenkins prod.

Also adds a reboot after GPU to make sure driver update is good to go.