### PR TITLE
Change master branch to main

### DIFF
--- a/gpuci-tools.sh
+++ b/gpuci-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Tools for gpuCI scripts
 
-URL="https://raw.githubusercontent.com/rapidsai/gpuci-mgmt/master/tools"
+URL="https://raw.githubusercontent.com/rapidsai/gpuci-mgmt/main/tools"
 
 function logging {
   TS=`date`


### PR DESCRIPTION
This PR updates an outdated reference to the `master` branch to use `main` instead.