### PR TITLE
cron auto-clean docker images

### DIFF
--- a/init/aws-ebs-gpu.sh
+++ b/init/aws-ebs-gpu.sh
@@ -45,6 +45,27 @@ logger "Ensure docker system is clean"
 set +e
 docker system prune -f
 
+# Setup hourly cron to prune images
+sudo cat > /etc/docker/image-prune.sh <<EOF
+#!/bin/bash
+
+df -h -t ext4
+docker images
+docker image prune -a -f --filter "until=12h"
+docker images
+docker volume ls
+docker volume prune -f
+docker volume ls
+docker container ls
+docker container prune -f
+docker container ls
+df -h -t ext4
+EOF
+sudo chmod +x /etc/docker/image-prune.sh
+sudo crontab -l > /tmp/existing-crons | true
+sudo echo "0 */3 * * * /etc/docker/image-prune.sh" >> /tmp/existing-crons
+sudo crontab /tmp/existing-crons
+
 logger "Connect node to Jenkins"
 wget https://gpuci.gpuopenanalytics.com/plugin/ec2/AMI-Scripts/ubuntu-ami-setup.sh
 sudo sh ubuntu-ami-setup.sh gpuci.gpuopenanalytics.com

--- a/init/aws-ebs-nvdocker.sh
+++ b/init/aws-ebs-nvdocker.sh
@@ -41,6 +41,27 @@ sudo service docker start
 # Ensure docker system is clean
 docker system prune -f
 
+# Setup hourly cron to prune images
+sudo cat > /etc/docker/image-prune.sh <<EOF
+#!/bin/bash
+
+df -h -t ext4
+docker images
+docker image prune -a -f --filter "until=12h"
+docker images
+docker volume ls
+docker volume prune -f
+docker volume ls
+docker container ls
+docker container prune -f
+docker container ls
+df -h -t ext4
+EOF
+sudo chmod +x /etc/docker/image-prune.sh
+sudo crontab -l > /tmp/existing-crons | true
+sudo echo "0 */3 * * * /etc/docker/image-prune.sh" >> /tmp/existing-crons
+sudo crontab /tmp/existing-crons
+
 # Connect node to Jenkins
 wget https://gpuci.gpuopenanalytics.com/plugin/ec2/AMI-Scripts/ubuntu-ami-setup.sh
 sudo sh ubuntu-ami-setup.sh gpuci.gpuopenanalytics.com

--- a/init/aws-ebs.sh
+++ b/init/aws-ebs.sh
@@ -39,6 +39,28 @@ logger "Ensure docker system is clean"
 set +e
 docker system prune -f
 
+# Setup hourly cron to prune images
+sudo cat > /etc/docker/image-prune.sh <<EOF
+#!/bin/bash
+
+df -h -t ext4
+docker images
+docker image prune -a -f --filter "until=12h"
+docker images
+docker volume ls
+docker volume prune -f
+docker volume ls
+docker container ls
+docker container prune -f
+docker container ls
+df -h -t ext4
+EOF
+sudo chmod +x /etc/docker/image-prune.sh
+sudo crontab -l > /tmp/existing-crons | true
+sudo echo "0 */3 * * * /etc/docker/image-prune.sh" >> /tmp/existing-crons
+sudo crontab /tmp/existing-crons
+
 logger "Connect node to Jenkins"
 wget https://gpuci.gpuopenanalytics.com/plugin/ec2/AMI-Scripts/ubuntu-ami-setup.sh
 sudo sh ubuntu-ami-setup.sh gpuci.gpuopenanalytics.com
+

--- a/init/aws-nvme-docker-gpu.sh
+++ b/init/aws-nvme-docker-gpu.sh
@@ -74,6 +74,27 @@ logger "Ensure docker system is clean"
 set +e
 docker system prune -f
 
+# Setup hourly cron to prune images
+sudo cat > /etc/docker/image-prune.sh <<EOF
+#!/bin/bash
+
+df -h -t ext4
+docker images
+docker image prune -a -f --filter "until=12h"
+docker images
+docker volume ls
+docker volume prune -f
+docker volume ls
+docker container ls
+docker container prune -f
+docker container ls
+df -h -t ext4
+EOF
+sudo chmod +x /etc/docker/image-prune.sh
+sudo crontab -l > /tmp/existing-crons | true
+sudo echo "0 */3 * * * /etc/docker/image-prune.sh" >> /tmp/existing-crons
+sudo crontab /tmp/existing-crons
+
 logger "Connect node to Jenkins"
 wget https://gpuci.gpuopenanalytics.com/plugin/ec2/AMI-Scripts/ubuntu-ami-setup.sh
 sudo sh ubuntu-ami-setup.sh gpuci.gpuopenanalytics.com

--- a/init/aws-nvme-docker.sh
+++ b/init/aws-nvme-docker.sh
@@ -67,6 +67,27 @@ logger "Ensure docker system is clean"
 set +e
 docker system prune -f
 
+# Setup hourly cron to prune images
+sudo cat > /etc/docker/image-prune.sh <<EOF
+#!/bin/bash
+
+df -h -t ext4
+docker images
+docker image prune -a -f --filter "until=12h"
+docker images
+docker volume ls
+docker volume prune -f
+docker volume ls
+docker container ls
+docker container prune -f
+docker container ls
+df -h -t ext4
+EOF
+sudo chmod +x /etc/docker/image-prune.sh
+sudo crontab -l > /tmp/existing-crons | true
+sudo echo "0 */3 * * * /etc/docker/image-prune.sh" >> /tmp/existing-crons
+sudo crontab /tmp/existing-crons
+
 logger "Connect node to Jenkins"
 wget https://gpuci.gpuopenanalytics.com/plugin/ec2/AMI-Scripts/ubuntu-ami-setup.sh
 sudo sh ubuntu-ami-setup.sh gpuci.gpuopenanalytics.com

--- a/init/aws-nvme.sh
+++ b/init/aws-nvme.sh
@@ -58,6 +58,27 @@ logger "Ensure docker system is clean"
 set +e
 docker system prune -f
 
+# Setup hourly cron to prune images
+sudo cat > /etc/docker/image-prune.sh <<EOF
+#!/bin/bash
+
+df -h -t ext4
+docker images
+docker image prune -a -f --filter "until=12h"
+docker images
+docker volume ls
+docker volume prune -f
+docker volume ls
+docker container ls
+docker container prune -f
+docker container ls
+df -h -t ext4
+EOF
+sudo chmod +x /etc/docker/image-prune.sh
+sudo crontab -l > /tmp/existing-crons | true
+sudo echo "0 */3 * * * /etc/docker/image-prune.sh" >> /tmp/existing-crons
+sudo crontab /tmp/existing-crons
+
 logger "Connect node to Jenkins"
 wget https://gpuci.gpuopenanalytics.com/plugin/ec2/AMI-Scripts/ubuntu-ami-setup.sh
 sudo sh ubuntu-ami-setup.sh gpuci.gpuopenanalytics.com


### PR DESCRIPTION
# Summary of Changes

This PR adds a 3-hour docker image prune to our Jenkins agents. The image running is done with a cronjob setup with the init scripts.


# Testing evidence
```bash
root@ip-172-31-0-123:/var/log# tail -f /tmp/cron-log
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
DRIVER              VOLUME NAME
Total reclaimed space: 0B
DRIVER              VOLUME NAME
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
Total reclaimed space: 0B
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
Filesystem      Size  Used Avail Use% Mounted on
/dev/nvme1n1p1   12G  2.8G  8.8G  25% /
/dev/nvme0n1     69G   54M   65G   1% /jenkins
Filesystem      Size  Used Avail Use% Mounted on
/dev/nvme1n1p1   12G  2.8G  8.8G  25% /
/dev/nvme0n1     69G   54M   65G   1% /jenkins
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
Total reclaimed space: 0B
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
DRIVER              VOLUME NAME
Total reclaimed space: 0B
DRIVER              VOLUME NAME
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
Total reclaimed space: 0B
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
Filesystem      Size  Used Avail Use% Mounted on
/dev/nvme1n1p1   12G  2.8G  8.8G  25% /
/dev/nvme0n1     69G   54M   65G   1% /jenkins
^C

```
