### PR TITLE
add GCE gpuCI packer template

### DIFF
--- a/templates/template-gce.json
+++ b/templates/template-gce.json
@@ -1,0 +1,47 @@
+{
+    "variables": {
+      "source_image_family": "ubuntu-1804-lts",
+      "machine_type": "e2-medium",
+      "type": "cpu",
+      "arch": "amd64",
+      "key_file": "gce-key.json"
+    },
+    "builders": [
+      {
+        "type": "googlecompute",
+        "account_file": "{{user `key_file`}}",
+        "project_id": "nv-ai-infra",
+        "machine_type": "{{user `machine_type`}}",
+        "source_image_family": "{{user `source_image_family`}}",
+        "zone": "us-central1-a",
+        "image_description": "gpuCI {{user `type` | upper}}-{{user `arch` | upper}} Ubuntu 18.04",
+        "image_name": "gpuci-{{user `type`}}-{{user `arch`}}-{{isotime | clean_resource_name}}",
+        "disk_size": 12,
+        "disk_type": "pd-ssd",
+        "ssh_username": "ubuntu",
+        "subnetwork": "gpuci-uscentral1",
+        "network": "gpuci-vpc",
+        "network_project_id": "nv-ai-infra"
+      }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "script": "bootstrap.sh",
+            "execute_command": "sudo env {{ .Vars }} {{ .Path }}"
+        },
+        {
+            "type": "ansible",
+            "playbook_file": "playbook.yml",
+            "groups": [
+                "{{user `type`}}"
+            ],
+            "user": "ubuntu"
+        },
+        {
+            "type": "shell",
+            "script": "post_build.sh"
+        }
+    ]
+}
+  


### PR DESCRIPTION
# Summary
This PR adds a Packer template for gpuCI on GCE.

# Testing Evidence
https://gpuci.gpuopenanalytics.com/job/gpuci/job/gpuci-mgmt/job/packer-gcp-build/31/console