### PR TITLE
update Jenkins aws, gcp uid

### DIFF
--- a/templates/roles/gpu/tasks/main.yml
+++ b/templates/roles/gpu/tasks/main.yml
@@ -43,7 +43,7 @@
     groups:
       - docker
       - wheel
-    uid: 1001
+    uid: 10000
     append: yes
 
 - name: Add authorized keys


### PR DESCRIPTION
# Summary
This PR update the Jenkins uid to 10000 for both AWS and GCP.

# Testing Evidence
https://gpuci.gpuopenanalytics.com/job/gpuci/job/gpuci-mgmt/job/packer-gcp-build/36/console