### PR TITLE
Install and hold CUDA 11.2 packages

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ex
+sleep 30
 df -h
 lsblk
 apt-get update

--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -ex
-sleep 30
 df -h
 lsblk
 apt-get update

--- a/templates/roles/gpu/tasks/main.yml
+++ b/templates/roles/gpu/tasks/main.yml
@@ -15,13 +15,69 @@
   apt_repository:
     repo: "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /"
 
-- name: Install CUDA 11.0
+- name: Install CUDA 11.2
   apt:
-    name: ['cuda=11.0.2-1','cuda-11-0=11.0.2-1','cuda-runtime-11-0=11.0.2-1','cuda-drivers=450.51.05-1','cuda-drivers-450=450.51.05-1']
+    name:
+      - cuda=11.2.2-1
+      - cuda-11-2=11.2.2-1
+      - cuda-runtime-11-2=11.2.2-1
+      - cuda-drivers=460.32.03-1
+      - cuda-drivers-460=460.32.03-1
+      - nvidia-driver-460=460.32.03-0ubuntu1
+      - libnvidia-gl-460=460.32.03-0ubuntu1
+      - nvidia-dkms-460=460.32.03-0ubuntu1
+      - nvidia-kernel-source-460=460.32.03-0ubuntu1
+      - nvidia-kernel-common-460=460.32.03-0ubuntu1
+      - libnvidia-common-460=460.32.03-0ubuntu1
+      - libnvidia-compute-460=460.32.03-0ubuntu1
+      - libnvidia-extra-460=460.32.03-0ubuntu1
+      - nvidia-compute-utils-460=460.32.03-0ubuntu1
+      - libnvidia-decode-460=460.32.03-0ubuntu1
+      - libnvidia-encode-460=460.32.03-0ubuntu1
+      - xserver-xorg-video-nvidia-460=460.32.03-0ubuntu1
+      - nvidia-modprobe=460.32.03-0ubuntu1
+      - nvidia-utils-460=460.32.03-0ubuntu1
+      - libnvidia-cfg1-460=460.32.03-0ubuntu1
+      - libnvidia-ifr1-460=460.32.03-0ubuntu1
+      - libnvidia-fbc1-460=460.32.03-0ubuntu1
     state: present
     install_recommends: no
     update_cache: yes
 
+- name: Update all packages to their latest version
+  apt:
+    name: "*"
+    state: latest
+    update_cache: yes
+
+- name: Hold CUDA Packages
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop:
+    - cuda
+    - cuda-11-2
+    - cuda-runtime-11-2
+    - cuda-drivers
+    - cuda-drivers-460
+    - nvidia-driver-460
+    - libnvidia-gl-460
+    - nvidia-dkms-460
+    - nvidia-kernel-source-460
+    - nvidia-kernel-common-460
+    - libnvidia-common-460
+    - libnvidia-compute-460
+    - libnvidia-extra-460
+    - nvidia-compute-utils-460
+    - libnvidia-decode-460
+    - libnvidia-encode-460
+    - xserver-xorg-video-nvidia-460
+    - nvidia-modprobe
+    - nvidia-utils-460
+    - libnvidia-cfg1-460
+    - libnvidia-ifr1-460
+    - libnvidia-fbc1-460
+  
 - name: Install nvidia docker apt key
   apt_key:
     url: https://nvidia.github.io/nvidia-docker/gpgkey

--- a/templates/template-gce.json
+++ b/templates/template-gce.json
@@ -16,7 +16,7 @@
         "zone": "us-central1-a",
         "image_description": "gpuCI {{user `type` | upper}}-{{user `arch` | upper}} Ubuntu 18.04",
         "image_name": "gpuci-{{user `type`}}-{{user `arch`}}-{{isotime | clean_resource_name}}",
-        "disk_size": 12,
+        "disk_size": 20,
         "disk_type": "pd-ssd",
         "ssh_username": "ubuntu",
         "subnetwork": "gpuci-uscentral1",

--- a/templates/template.json
+++ b/templates/template.json
@@ -34,7 +34,7 @@
             "launch_block_device_mappings": [
                 {
                     "device_name": "/dev/sda1",
-                    "volume_size": 12,
+                    "volume_size": 20,
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }


### PR DESCRIPTION
1) Install CUDA 11.2
2) Hold CUDA/NVIDIA packages from upgrading
3) Increase disk size for larger CUDA
4) Remove unnecessary `sleep` command