### PR TITLE
Fix A100 images

### DIFF
--- a/templates/bootstrap.sh
+++ b/templates/bootstrap.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
-sleep 30
+if [[ "$PACKER_BUILDER_TYPE" != "docker" ]]; then
+    sleep 30
+fi
 df -h
 lsblk
 apt-get update

--- a/templates/roles/common/tasks/main.yml
+++ b/templates/roles/common/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Set timezone to PT
-  timezone:
-    name: America/Los_Angeles
-
 - name: Install common packages
   apt:
     update_cache: yes
@@ -25,6 +21,11 @@
       - unzip
       - sudo
       - chrony
+      - tzdata
+
+- name: Set timezone to PT
+  timezone:
+    name: America/Los_Angeles
 
 - name: Configure Chrony
   copy:
@@ -118,10 +119,16 @@
     repo: "deb [arch=arm64] https://download.docker.com/linux/ubuntu bionic stable"
   when: ansible_architecture == "aarch64"
 
+- name: Install Docker CE
+  apt: 
+    update_cache: yes
+    pkg: 
+      - docker-ce
+      - docker-ce-cli
+
 - name: Create rc.local
   copy:
     dest: /etc/rc.local
     mode: '0555'
     content: |
       #!/bin/bash
-

--- a/templates/roles/cpu/tasks/main.yml
+++ b/templates/roles/cpu/tasks/main.yml
@@ -1,5 +1,1 @@
 ---
-- name: Install Docker CE
-  apt: 
-    update_cache: yes
-    name: docker-ce

--- a/templates/roles/gpu/tasks/main.yml
+++ b/templates/roles/gpu/tasks/main.yml
@@ -1,11 +1,4 @@
 ---    
-- name: Install Docker CE 18.09
-  apt: 
-    update_cache: yes
-    pkg:
-      - docker-ce=5:18.09.1~3-0~ubuntu-bionic
-      - docker-ce-cli=5:18.09.1~3-0~ubuntu-bionic
-
 - name: Add key for NVIDIA CUDA repos
   apt_key:
     url: http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub


### PR DESCRIPTION
1) Only sleep for non-docker builds
2) More reliably set the timezone by ensuring tzdata is installed
3) Install the latest docker version regardless of cpu or gpu type