### PR TITLE
Update AMIs to Ubuntu 20.04

### DIFF
--- a/templates/docker.json
+++ b/templates/docker.json
@@ -7,7 +7,7 @@
     "builders": [
         {
             "type": "docker",
-            "image": "ubuntu:18.04",
+            "image": "ubuntu:20.04",
             "commit": true,
             "run_command": [
                 "-d",

--- a/templates/packer-ansible.dockerfile
+++ b/templates/packer-ansible.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV PATH=/root:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/templates/roles/common/tasks/main.yml
+++ b/templates/roles/common/tasks/main.yml
@@ -22,6 +22,7 @@
       - sudo
       - chrony
       - tzdata
+      - acl
 
 - name: Set timezone to PT
   timezone:
@@ -132,3 +133,9 @@
     mode: '0555'
     content: |
       #!/bin/bash
+
+- name: Configure python alternative
+  alternatives:
+    name: python
+    link: /usr/bin/python
+    path: /usr/bin/python3.8

--- a/templates/roles/common/tasks/main.yml
+++ b/templates/roles/common/tasks/main.yml
@@ -3,7 +3,6 @@
   apt:
     update_cache: yes
     pkg:
-      - jq
       - ansible
       - openjdk-8-jdk-headless
       - git
@@ -132,3 +131,10 @@
     mode: '0555'
     content: |
       #!/bin/bash
+
+- name: Install jq
+  get_url:
+    url: https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+    dest: /usr/local/bin/jq
+    mode: '0755'
+

--- a/templates/roles/common/tasks/main.yml
+++ b/templates/roles/common/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     update_cache: yes
     pkg:
+      - jq
       - ansible
       - openjdk-8-jdk-headless
       - git
@@ -131,10 +132,3 @@
     mode: '0555'
     content: |
       #!/bin/bash
-
-- name: Install jq
-  get_url:
-    url: https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-    dest: /usr/local/bin/jq
-    mode: '0755'
-

--- a/templates/roles/common/tasks/main.yml
+++ b/templates/roles/common/tasks/main.yml
@@ -111,12 +111,12 @@
 
 - name: Add Docker apt repository (x86_64)
   apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
   when: ansible_architecture == "x86_64"
 
 - name: Add Docker apt repository (aarch64)
   apt_repository:
-    repo: "deb [arch=arm64] https://download.docker.com/linux/ubuntu bionic stable"
+    repo: "deb [arch=arm64] https://download.docker.com/linux/ubuntu focal stable"
   when: ansible_architecture == "aarch64"
 
 - name: Install Docker CE

--- a/templates/roles/gpu/tasks/main.yml
+++ b/templates/roles/gpu/tasks/main.yml
@@ -1,12 +1,12 @@
 ---    
 - name: Add key for NVIDIA CUDA repos
   apt_key:
-    url: http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+    url: http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
     state: present
 
 - name: Add repo for NVIDIA CUDA drivers
   apt_repository:
-    repo: "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /"
+    repo: "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /"
 
 - name: Install CUDA 11.4
   apt:
@@ -77,7 +77,7 @@
 
 - name: Add nvidia-docker sources list
   get_url:
-    url: https://nvidia.github.io/nvidia-docker/ubuntu18.04/nvidia-docker.list
+    url: https://nvidia.github.io/nvidia-docker/ubuntu20.04/nvidia-docker.list
     dest: /etc/apt/sources.list.d/nvidia-docker.list
 
 - name: Install nvidia-docker2

--- a/templates/template-gce.json
+++ b/templates/template-gce.json
@@ -1,6 +1,6 @@
 {
     "variables": {
-      "source_image_family": "ubuntu-1804-lts",
+      "source_image_family": "ubuntu-2004-lts",
       "machine_type": "e2-medium",
       "type": "cpu",
       "arch": "amd64",
@@ -14,7 +14,7 @@
         "machine_type": "{{user `machine_type`}}",
         "source_image_family": "{{user `source_image_family`}}",
         "zone": "us-central1-a",
-        "image_description": "gpuCI {{user `type` | upper}}-{{user `arch` | upper}} Ubuntu 18.04",
+        "image_description": "gpuCI {{user `type` | upper}}-{{user `arch` | upper}} Ubuntu 20.04",
         "image_name": "gpuci-{{user `type`}}-{{user `arch`}}-{{isotime | clean_resource_name}}",
         "disk_size": 20,
         "disk_type": "pd-ssd",

--- a/templates/template.json
+++ b/templates/template.json
@@ -15,7 +15,7 @@
             "source_ami_filter": {
                 "filters": {
                     "virtualization-type": "hvm",
-                    "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-{{user `arch`}}-server-*",
+                    "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-{{user `arch`}}-server-*",
                     "root-device-type": "ebs"
                 },
                 "owners": [
@@ -30,7 +30,7 @@
             "security_group_id": "sg-011a953aa80956de1",
             "ssh_username": "ubuntu",
             "ami_name": "gpuci-{{user `type`}}-{{user `arch`}}-{{isotime | clean_resource_name}}",
-            "ami_description": "gpuCI {{user `type` | upper}}-{{user `arch` | upper}} Ubuntu 18.04",
+            "ami_description": "gpuCI {{user `type` | upper}}-{{user `arch` | upper}} Ubuntu 20.04",
             "launch_block_device_mappings": [
                 {
                     "device_name": "/dev/sda1",
@@ -43,7 +43,7 @@
                 "role": "gpuci",
                 "type": "{{user `type`}}",
                 "arch": "{{user `arch`}}",
-                "os": "ubuntu18.04"
+                "os": "ubuntu20.04"
             }
         }
     ],


### PR DESCRIPTION
~~The `jq` version available from Ubuntu's repositories is `1.5`, but there is a feature in `1.6` that I'd like to start leveraging (the `$ENV` builtin to access environmental variables, link).~~

~~This PR updates the way we install `jq` to grab the latest `1.6` binary from GitHub instead of installing via `apt`.~~

This PR updates our AMIs to Ubuntu20.04. This change aligns with the recent updates to our lab machines. It also provides some updated packages (i.e. `jq` version `1.6` instead of `1.5`).