### PR TITLE
remove unneeded instance profile

### DIFF
--- a/templates/template.json
+++ b/templates/template.json
@@ -24,7 +24,6 @@
                 "most_recent": true
             },
             "instance_type": "{{user `instance`}}",
-            "iam_instance_profile": "jenkins-agents",
             "associate_public_ip_address": true,
             "vpc_id": "vpc-81eb9ae9",
             "subnet_id": "subnet-45f29e2d",


### PR DESCRIPTION
This PR removes `iam_instance_profile` added to the packer template #32. We found that adding entry did not achieve the intended effect of attaching the associated `iam_role` to the spun up EC2 instances.