### PR TITLE
Fix `jenkins-update-ec2-ami.py` script

### DIFF
--- a/templates/jenkins-update-ec2-ami.py
+++ b/templates/jenkins-update-ec2-ami.py
@@ -56,13 +56,23 @@ def update_jenkins_ami_id(cpu_ami_amd64, cpu_ami_arm64, gpu_ami_amd64):
             return false
         }
 
+        def is_cpu(display_name) {
+            display_name = display_name.toLowerCase()
+            cpu_descriptions = ["cpu", "builder", "runner"]
+            for (desc in cpu_descriptions) {
+                if (display_name.contains(desc)) {
+                    return true
+                }
+            }
+            return false
+        }
 
         Jenkins.instance.clouds.each { cloud ->
             if (cloud instanceof AmazonEC2Cloud) {
                 cloud.getTemplates().each { agent ->
-                    if (agent.getDisplayName().toLowerCase().contains("cpu")) {
+                    if (is_cpu(agent.getDisplayName())) {
                         agent.setAmi("%s")
-                        if (is_arm(agent.type.toString())) agent.setAmi('%s')    
+                        if (is_arm(agent.type.toString())) agent.setAmi('%s')
                     }
                     if (agent.getDisplayName().toLowerCase().contains("gpu")) agent.setAmi("%s")
                 }


### PR DESCRIPTION
The `jenkins-update-ec2-ami.py` script wasn't updating all of the CPU machine configurations. It was only updating machines whose display name contained `cpu`, but was not updating the `runner` or `builder` nodes. This PR fixes that.