### PR TITLE
Update Java

### DIFF
--- a/templates/roles/common/tasks/main.yml
+++ b/templates/roles/common/tasks/main.yml
@@ -5,7 +5,7 @@
     pkg:
       - jq
       - ansible
-      - openjdk-8-jdk-headless
+      - openjdk-11-jdk-headless
       - git
       - git-lfs
       - nvme-cli


### PR DESCRIPTION
This PR updates the Java version to 11, which is required for the latest version of Jenkins that we've upgraded to.