### PR TITLE
Remove docker mirror

### DIFF
--- a/init/aws-ebs-gpu.sh
+++ b/init/aws-ebs-gpu.sh
@@ -20,7 +20,7 @@ logger "Ensure jenkins user has full rights on directory for Jenkins work"
 sudo mkdir -p /jenkins
 sudo chown -R jenkins:jenkins /jenkins
 
-logger "Override docker setup and utilize internal docker registry mirror"
+logger "Override docker setup"
 sudo service docker stop
 if [ -f /etc/docker/daemon.json ]; then
   sudo cat /etc/docker/daemon.json
@@ -33,7 +33,6 @@ cat <<EOL > /tmp/daemon.json
             "runtimeArgs": []
         }
     },
-    "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],
     "experimental": true
 }
 EOL

--- a/init/aws-ebs-nvdocker.sh
+++ b/init/aws-ebs-nvdocker.sh
@@ -17,7 +17,7 @@ df -h
 sudo mkdir -p /jenkins
 sudo chown -R ubuntu:ubuntu /jenkins
 
-# Override docker setup and utilize internal docker registry mirror
+# Override docker setup
 sudo service docker stop
 if [ -f /etc/docker/daemon.json ]; then
   sudo cat /etc/docker/daemon.json
@@ -30,7 +30,6 @@ cat <<EOL > /tmp/daemon.json
             "runtimeArgs": []
         }
     },
-    "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],
     "experimental": true
 }
 EOL

--- a/init/aws-ebs.sh
+++ b/init/aws-ebs.sh
@@ -20,14 +20,13 @@ logger "Ensure ubuntu user has full rights on directory for Jenkins work"
 sudo mkdir -p /jenkins
 sudo chown -R ubuntu:ubuntu /jenkins
 
-logger "Override docker setup and utilize internal docker registry mirror"
+logger "Override docker setup"
 sudo service docker stop
 if [ -f /etc/docker/daemon.json ]; then
   sudo cat /etc/docker/daemon.json
 fi
 cat <<EOL > /tmp/daemon.json
 {
-    "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],
     "experimental": true
 }
 EOL

--- a/init/aws-nvme-docker-gpu.sh
+++ b/init/aws-nvme-docker-gpu.sh
@@ -40,7 +40,7 @@ else
   logger "/jenkins/tmp already exists"
 fi
   
-logger "Override docker setup and utilize internal docker registry mirror"
+logger "Override docker setup"
 sudo service docker stop
 sudo cat /etc/docker/daemon.json
 cat <<EOL > /tmp/daemon.json
@@ -51,7 +51,6 @@ cat <<EOL > /tmp/daemon.json
             "runtimeArgs": []
         }
     },
-    "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],
     "experimental": true
 }
 EOL

--- a/init/aws-nvme-docker.sh
+++ b/init/aws-nvme-docker.sh
@@ -39,14 +39,13 @@ else
   logger "/jenkins/tmp already exists"
 fi
   
-logger "Override docker setup and utilize internal docker registry mirror"
+logger "Override docker setup"
 sudo service docker stop
 if [ -f /etc/docker/daemon.json ]; then
   sudo cat /etc/docker/daemon.json
 fi
 cat <<EOL > /tmp/daemon.json
 {
-    "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],
     "experimental": true
 }
 EOL

--- a/init/aws-nvme.sh
+++ b/init/aws-nvme.sh
@@ -39,14 +39,13 @@ else
   logger "/jenkins/tmp already exists"
 fi
   
-logger "Override docker setup and utilize internal docker registry mirror"
+logger "Override docker setup"
 sudo service docker stop
 if [ -f /etc/docker/daemon.json ]; then
   sudo cat /etc/docker/daemon.json
 fi
 cat <<EOL > /tmp/daemon.json
 {
-    "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],
     "experimental": true
 }
 EOL

--- a/init/gcp-docker.sh
+++ b/init/gcp-docker.sh
@@ -15,7 +15,7 @@ function logger {
 logger "Update/upgrade image first; before unattended-upgrades runs"
 sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get clean
 
-logger "Override docker setup and utilize internal docker registry mirror"
+logger "Override docker setup"
 sudo service docker stop
 if [ -f /etc/docker/daemon.json ]; then
   sudo cat /etc/docker/daemon.json
@@ -28,7 +28,6 @@ cat <<EOL > /tmp/daemon.json
             "runtimeArgs": []
         }
     },
-    "registry-mirrors": ["http://docker-mirror.rapids.ai:5000"],
     "experimental": true
 }
 EOL


### PR DESCRIPTION
We are dropping the docker registry mirror from our AWS account, so remove it from the init scripts.